### PR TITLE
[homepage] Blend live masternode chart with gray background

### DIFF
--- a/src/scss/pages/_home.scss
+++ b/src/scss/pages/_home.scss
@@ -110,29 +110,25 @@ $homeSectionPaddingTop: 80px;
 		}
 	}
 
-  .home-network-graphic-live {
-	min-height: 350px;
-	max-width: none;
+	.home-network-graphic-live {
+		position: relative;
+		min-height: 350px;
+		max-width: none;
 
-	@media (min-width: 768px) {
-	  z-index: 1;
-	  > img {
-		right: -20px;
-		bottom: -50px;
-		max-width: 150%;
-	  }
-	  &:after {
-		content: '';
-		position: absolute;
-		right: -20px;
-		bottom: -50px;
-		width: 819px;
-		height: 339px;
-		max-width: 150%;
-		background: linear-gradient(to right, $color-gray-light, rgba($color-gray-light, 0.5) 13%, rgba($color-gray-light, 0) 85%);
-	  }
+		@supports (mix-blend-mode: multiply) {
+			&:after {
+				content: '';
+				position: absolute;
+				top: 0;
+				bottom: 0;
+				left: 0;
+				right: 0;
+				background-color: $color-gray-light;
+				mix-blend-mode: multiply;
+				pointer-events: none;
+			}
+		}
 	}
-  }
 
 	.home-evolution-graphic {
 		@media (min-width: 768px) {


### PR DESCRIPTION
progressive enhancement -- in browsers that support "mix-blend-mode" (firefox, chrome) the masternode chart will blend in with the gray background behind it