### PR TITLE
Speeding up Jekyll build by limiting rebuilds on images for language …

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,4 +54,4 @@ srcset:
   source: assets/img
   output: assets/img/resized
 
-keep_files: ['assets/img/resized']
+keep_files: ['assets/img/resized','es/assets/img/resized','cn/assets/img/resized','pt/assets/img/resized','ru/assets/img/resized','it/assets/img/resized']


### PR DESCRIPTION
…assets using 'keep_files' config option on language folders.