### PR TITLE
make new page for /payments

### DIFF
--- a/_data/payment-processors.yml
+++ b/_data/payment-processors.yml
@@ -1,0 +1,51 @@
+- name: CoinPayments
+  description: 'Fees: Transaction 0.50%; Withdrawal Network transaction fee (TX)'
+  logo_url: "https://www.dash.org/wp-content/uploads/2014/09/coinpayments_logo.png"
+  type: payment
+  vendor_id: ledger
+  vendor_label: CoinPayments
+  product_id: CoinPayments
+  product_label: CoinPayments
+  links:
+    -
+      label: coinpayments.net
+      url: "https://www.coinpayments.net/"
+
+- name:  Cointopay
+  description: 'Fees: Transaction 0.25% + 0.0005 DASH; Withdrawal 0.01 DASH'
+  logo_url: "https://www.dash.org/wp-content/uploads/2014/09/cointopay_logo.png"
+  type: payment
+  vendor_id: Cointopay
+  vendor_label: Cointopay
+  product_id: Cointopay
+  product_label: Cointopay
+  links:
+    -
+      label: cointopay.com
+      url: "https://cointopay.com/"
+
+- name: eDigiCash
+  description: 'Fees: Transaction 0.5%; Withdrawal Included with transaction fee'
+  logo_url: "https://www.dash.org/wp-content/uploads/2014/10/edigicash_logo.png"
+  type: payment
+  vendor_id: eDigiCash
+  vendor_label: eDigiCash
+  product_id: eDigiCash
+  product_label: eDigiCash
+  links:
+    -
+      label: edigicash.co
+      url: "https://www.edigicash.co/"
+      
+- name: GoUrl.io
+  description: 'Fees: N/A'
+  logo_url: "https://www.dash.org/wp-content/uploads/2015/05/gourlio_logo.png"
+  type: payment
+  vendor_id: GoUrl.io
+  vendor_label: GoUrl.io
+  product_id: GoUrl.io
+  product_label: GoUrl.io
+  links:
+    -
+      label: gourl.io
+      url: "https://gourl.io/"

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -240,9 +240,18 @@ pages:
     wallets-paper-header: Paper
     wallets-paper-subtitle: Paper wallets are a form of cold wallet and essentially a bearer instrument.
     wallets-security-header: Security
+    wallets-security-subtitle: Please secure your wallets by protecting them with strong, difficult-to-guess passwords and by backing them up in a secure place. Always choose to encrypt your wallet and any backups, because if your funds are lost or stolen, there is no way to recover them. If using a hardware (HD) wallet such as a paper wallet or keepass, please secure your "seeds" just as you would a regular wallet password. They are the only way to recover your wallet. For help on securing passwords, visit
     modal-platform: Platform
 
-    wallets-security-subtitle: Please secure your wallets by protecting them with strong, difficult-to-guess passwords and by backing them up in a secure place. Always choose to encrypt your wallet and any backups, because if your funds are lost or stolen, there is no way to recover them. If using a hardware (HD) wallet such as a paper wallet or keepass, please secure your "seeds" just as you would a regular wallet password. They are the only way to recover your wallet. For help on securing passwords, visit
+  payments:
+    title: Dash Payment Processors
+    hero-heading: Send Payments in DASH
+    hero-text: To be added...something something about benefits and ease of paying dash
+    payments-desc-header: Payment Processors
+    payments-desc-subtitle: To be added...
+    payments-providers-header: Payment Processors
+    payments-providers-subtitle: To be added... 
+
     modal-header-vendor-label-descriptor: Wallet for Dash
     modal-download-action-button-label: Download
     modal-source-code-view: View

--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -245,12 +245,12 @@ pages:
 
   payments:
     title: Dash Payment Processors
-    hero-heading: Send Payments in DASH
-    hero-text: To be added...something something about benefits and ease of paying dash
+    hero-heading: Dash Payment Processing
+    hero-text: Quickly and easily integrate Dash as a payment method
     payments-desc-header: Payment Processors
-    payments-desc-subtitle: To be added...
+    payments-desc-subtitle: 
     payments-providers-header: Payment Processors
-    payments-providers-subtitle: To be added... 
+    payments-providers-subtitle: 
 
     modal-header-vendor-label-descriptor: Wallet for Dash
     modal-download-action-button-label: Download

--- a/_includes/hero/merchants.html
+++ b/_includes/hero/merchants.html
@@ -15,7 +15,7 @@
 
 		<div class="hero__buttons">
 			<a href="https://www.zeemaps.com/map?group=2357566#" target="_blank" class="btn-white-solid">{% t pages.merchants.hero-map-btn %}</a>
-			<a href="https://www.dash.org/payment-processors" target="_blank" class="btn-white-solid">{% t pages.merchants.hero-integrate-btn %}</a>
+			<a href="{{ base }}/payments" class="btn-white-solid">{% t pages.merchants.hero-integrate-btn %}</a>
 			<a href="https://dashpay.atlassian.net/wiki/x/GADeAQ" class="btn-white-solid"  target="_blank">{% t pages.merchants.hero-getlisted-btn %}</a>
 		</div>
 	</div>

--- a/_includes/hero/merchants.html
+++ b/_includes/hero/merchants.html
@@ -15,9 +15,8 @@
 
 		<div class="hero__buttons">
 			<a href="https://www.zeemaps.com/map?group=2357566#" target="_blank" class="btn-white-solid">{% t pages.merchants.hero-map-btn %}</a>
-			<a href="https://dashpay.atlassian.net/wiki/display/DOC/Merchants" target="_blank" class="btn-white-solid">{% t pages.merchants.hero-integrate-btn %}</a>
+			<a href="https://www.dash.org/payment-processors" target="_blank" class="btn-white-solid">{% t pages.merchants.hero-integrate-btn %}</a>
 			<a href="https://dashpay.atlassian.net/wiki/x/GADeAQ" class="btn-white-solid"  target="_blank">{% t pages.merchants.hero-getlisted-btn %}</a>
-			<a href="{{ basenav }}/woocommerce/" class="btn-white-solid">{% t pages.merchants.hero-woo-btn %}</a>
 		</div>
 	</div>
 

--- a/_includes/hero/payments.html
+++ b/_includes/hero/payments.html
@@ -1,13 +1,5 @@
 <div class="hero hero--space" id="hero">
 
-	<!--div class="hero__background">
-		{% capture heroimage %}hero/{% t pages.wallets.hero-image %}{% endcapture %}
-		{% srcset hero/get-dash-n.jpg ppi:1,2 class="hero__background-image" %}
-			{% srcset_source width:1920 %}
-			{% srcset_source width:960 %}
-		{% endsrcset %}
-	</div-->
-
 	<div class="hero__background">
 
 		<img src="{{ base }}/assets/img/hero/expecto_patronum.png" alt="" class="hero__background-image">
@@ -22,11 +14,6 @@
 		<h1 class="hero__title">{% t pages.payments.hero-heading %}</h1>
 		<p class="hero__lead">{% t pages.payments.hero-text %}</p>
 		
-		<!--<div class="hero__buttons">-->
-		<!--	<a href="#payments" class="btn-white-solid">{% t pages.payments.hero-wallets-btn %}</a>-->
-		<!--	<a href="https://dashpay.atlassian.net/wiki/pages/viewpage.action?pageId=1146941" target="_blank" class="btn-white-solid">{% t pages.payments.hero-guide-btn %}</a>-->
-		<!--	<a href="https://dashpay.atlassian.net/wiki/pages/viewpage.action?pageId=31326247" target="_blank" class="btn-white-solid">{% t pages.payments.hero-security-btn %}</a>-->
-		<!--</div>-->
 	</div>
 
 	<!-- Hero stripe -->

--- a/_includes/hero/payments.html
+++ b/_includes/hero/payments.html
@@ -1,0 +1,34 @@
+<div class="hero hero--space" id="hero">
+
+	<!--div class="hero__background">
+		{% capture heroimage %}hero/{% t pages.wallets.hero-image %}{% endcapture %}
+		{% srcset hero/get-dash-n.jpg ppi:1,2 class="hero__background-image" %}
+			{% srcset_source width:1920 %}
+			{% srcset_source width:960 %}
+		{% endsrcset %}
+	</div-->
+
+	<div class="hero__background">
+
+		<img src="{{ base }}/assets/img/hero/expecto_patronum.png" alt="" class="hero__background-image">
+
+	</div>
+
+	<!-- Navigation -->
+	{% include nav-desktop.html %}
+
+	<!-- Hero content -->
+	<div class="hero__content">
+		<h1 class="hero__title">{% t pages.payments.hero-heading %}</h1>
+		<p class="hero__lead">{% t pages.payments.hero-text %}</p>
+		
+		<!--<div class="hero__buttons">-->
+		<!--	<a href="#payments" class="btn-white-solid">{% t pages.payments.hero-wallets-btn %}</a>-->
+		<!--	<a href="https://dashpay.atlassian.net/wiki/pages/viewpage.action?pageId=1146941" target="_blank" class="btn-white-solid">{% t pages.payments.hero-guide-btn %}</a>-->
+		<!--	<a href="https://dashpay.atlassian.net/wiki/pages/viewpage.action?pageId=31326247" target="_blank" class="btn-white-solid">{% t pages.payments.hero-security-btn %}</a>-->
+		<!--</div>-->
+	</div>
+
+	<!-- Hero stripe -->
+	<div class="hero__stripe"></div>
+</div>

--- a/payments/index.html
+++ b/payments/index.html
@@ -1,0 +1,39 @@
+---
+layout: default
+title: pages.payments.title
+description: pages.payments.description
+---
+<!-- Update 201702090113_MST @chuckwilliams37 -->
+{% include hero/payments.html %}
+{% include modals/win-core.html %}
+
+{% assign payment-wallets = site.data.payment-processors| sort: "product_label" | where:"type","payment" %}
+
+{% include wallets_js_data.html %}
+
+{% for vendor-group in vendor-collection %}
+{% include modals/vendor-group-download-collection.html %}
+{% endfor %}
+
+<div class="page page--payments">
+
+	<section class="section clearfix">
+		<div class="section__content">
+			<h3>{% t pages.payments.payments-providers-header %}</h3>
+			<p>{% t pages.payments.payments-providers-subtitle %}</p>
+			<div class="row payments">
+				{% for wallet in payment-wallets %}
+				{% include wallet-tile.html %}
+				{% endfor %}
+			</div>
+		</div>
+	</section>
+
+	<section class="section clearfix">
+		<div class="section__content" style="background-color: #fff7af; width: 97%; margin: auto; padding: 10px 15px;">
+			<p >
+			DISCLAIMER: This list is provided for informational purposes only. Services listed here have not been evaluated or endorsed by the Dash developers and no guarantees are made as to the accuracy of this information. Please exercise discretion when using third-party services.
+			</p>
+		</div>
+	</section>
+</div>

--- a/payments/index.html
+++ b/payments/index.html
@@ -31,7 +31,7 @@ description: pages.payments.description
 
 	<section class="section clearfix">
 		<div class="section__content" style="background-color: #fff7af; width: 97%; margin: auto; padding: 10px 15px;">
-			<p >
+			<p>
 			DISCLAIMER: This list is provided for informational purposes only. Services listed here have not been evaluated or endorsed by the Dash developers and no guarantees are made as to the accuracy of this information. Please exercise discretion when using third-party services.
 			</p>
 		</div>

--- a/src/scss/_junk-drawer.scss
+++ b/src/scss/_junk-drawer.scss
@@ -30,6 +30,8 @@ you're in a hurry or lost or you just need to Make It Work©
   text-align: left;
 }
 
+
+
 $wallet-tile-min-height: 20em;
 $wallet-tile-max-width: 25em;
 $wallet-tile-logo-container-height: 5.5em;
@@ -46,6 +48,9 @@ $wallet-tile-hover-background-base-color: lighten($color-blue-light, 9);
   margin: $wallet-tile-spacing auto;
   border: 1px solid $color-gray;
   min-height: $wallet-tile-min-height;
+  .payments &{
+            min-height: 12em;
+        }
   max-width: $wallet-tile-max-width;
   overflow: hidden;
   -o-transition: .25s;
@@ -78,6 +83,9 @@ $wallet-tile-hover-background-base-color: lighten($color-blue-light, 9);
       overflow: hidden;
       img {
         max-height: 80px;
+        .payments &{
+          max-height: 60px;
+        }
       }
     }
     & .caption {


### PR DESCRIPTION
- new page for payments
- removed woocommerce button on merchants page
- redirected integrate dash (temporily to old word press page /payment-proccessors/ to be redirected to /payments/
- css changes in .../css/junk-drawer for payment tile styling 