### PR TITLE
clean up / simplify deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ script:
   - test -d _site/ && test -s _site/index.html
 
 before_deploy:
-  - ssh-keyscan -H -t rsa,dsa $hostname >> ~/.ssh/known_hosts
+  - openssl aes-256-cbc -k "$dash_org_pem_pass" -in dash.org-test-web.pem.enc -out /tmp/deploy_rsa -d
+  - eval "$(ssh-agent -s)"
+  - chmod 0600 /tmp/deploy_rsa
+  - ssh-add /tmp/deploy_rsa
 
 addons:
   ssh_known_hosts:
@@ -18,6 +21,6 @@ addons:
 deploy:
   provider: script
   skip_cleanup: true
-  script: bash script/deploy-rsync.sh
+  script: DEPLOY_USER=$STAGE_DEPLOY_USER DEPLOY_HOST=$STAGE_DEPLOY_HOST DEPLOY_PATH=$STAGE_DEPLOY_PATH bash script/deploy-rsync.sh
   on:
     branch: master

--- a/script/deploy-rsync.sh
+++ b/script/deploy-rsync.sh
@@ -1,19 +1,5 @@
-#!/bin/bash
+#! /bin/bash
 
-set -e
+set -xe
 
-# punt if PR
-if [[ $TRAVIS_PULL_REQUEST != 'false' ]]; then
-    echo "IS PULL REQUEST: Skipping deploy rsync"
-elif [[ ! -z "$dash_org_pem_pass" ]]; then
-    echo -n "DEPLOY - decrypting key..."
-    openssl aes-256-cbc -k "$dash_org_pem_pass" -in dash.org-test-web.pem.enc -out dash.org-test-web.pem -d
-    chmod 600 dash.org-test-web.pem
-    echo "DONE"
-    echo "DEPLOY - copying content..."
-    export RSYNC_RSH='ssh -i dash.org-test-web.pem'
-    rsync -r -c -v --delete-after --exclude-from 'ciexclude.txt' $TRAVIS_BUILD_DIR/_site/ $user@$hostname:$production_path
-    echo "DONE"
-else
-    echo "SKIPPING SITE DEPLOY "
-fi
+rync -vzrlptD --delete-after $TRAVIS_BUILD_DIR/_site/ $DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH


### PR DESCRIPTION
* extract/move ssh-specific items to travis before_deploy hook
* this allows multiple branches to be deployed to multiple hosts (e.g. master->stage, release->prod)
* remove un-necessary checks in deploy script (handled by travis deploy hook)