### PR TITLE
:bug: DW-408 Fix broken RSS feed

### DIFF
--- a/rss/dash_blog_rss.xml
+++ b/rss/dash_blog_rss.xml
@@ -11,17 +11,17 @@
 		<title>{{ site.name | xml_escape }}</title>
 		<description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>
 		<link>{{ site.url }}</link>
-		<atom:link href="{{ site.url }}/{{ page.path }}" rel="self" type="application/rss+xml" />
+		<atom:link href="{{ site.url }}/{{ page.path | xml_escape }}" rel="self" type="application/rss+xml" />
 		{% for post in site.posts %}
 			<item>
-				<title type="html">{{ post.title | xml_escape }}</title>
+				<title type="html"><![CDATA[{{ post.title }}]]></title>
 				{% if post.author.name %}
 					<dc:creator>{{ post.author.name | xml_escape }}</dc:creator>
 				{% endif %}
 				<description><![CDATA[{{ post.excerpt }}]]></description>
 				<pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-				<link>{{ site.url }}{{ post.url }}</link>
-				<guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
+				<link>{{ site.url }}{{ post.url | xml_escape }}</link>
+				<guid isPermaLink="true">{{ site.url }}{{ post.url | xml_escape }}</guid>
 				<content:encoded><![CDATA[{{ post.content }}]]></content:encoded>
 			</item>
 		{% endfor %}


### PR DESCRIPTION
This PR fixes DW-408, RSS feeds were broken due to an unescaped ampersand in URLs. The fix improves the RSS template to prevent this problem.