### PR TITLE
Style enhancement suggestion for grid (bottom of get-dash page)

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -786,8 +786,8 @@ pages:
     claim-heading: Buy, Sell, Exchange Dash
     claim-subline: Dash can be acquired, held and exchanged in many ways.
 
-    setup-heading: Learn how to set up your wallet
-    setup-text:
+    setup-heading: Set up your wallet
+    setup-text: Explore different kinds of wallets and learn how to set up your wallet
     setup-btn: Learn More
     setup-link: https://dashpay.atlassian.net/wiki/pages/viewpage.action?pageId=1146941
 

--- a/src/scss/_info-grid.scss
+++ b/src/scss/_info-grid.scss
@@ -7,7 +7,10 @@ $m: 'info-grid';
 	&__item {
 		@extend .col-md-4;
 		@extend .col-sm-6;
+		// background-color: $color-gray-light;	
 		margin-bottom: 70px;
+		text-align: center;
+		padding: 10px;
 
 
 		@include mq($to: small) {
@@ -24,7 +27,9 @@ $m: 'info-grid';
 			border-radius: 50%;
 			// border: 1px solid rgba($color-gray-dark, 0.1);
 			background-color: rgba($color-white, 0.5);
-			margin-bottom: 40px;
+			// margin-bottom: 40px;
+			margin-left: auto;
+			margin-right: auto;
 
 			@include mq($to: small) {
 				margin-left: auto;
@@ -42,10 +47,12 @@ $m: 'info-grid';
 			@include font-title-small();
 			text-transform: none;
 			margin-bottom: 0.5em;
+			// text-align: center;
 		}
 		&-text {
 			color: $color-gray-dark;
 			margin-bottom: 0.5em;
+			// text-align: center;
 		}
 		&-link {
 			@extend .btn-blue;

--- a/src/scss/_info-grid.scss
+++ b/src/scss/_info-grid.scss
@@ -27,7 +27,7 @@ $m: 'info-grid';
 			border-radius: 50%;
 			// border: 1px solid rgba($color-gray-dark, 0.1);
 			background-color: rgba($color-white, 0.5);
-			// margin-bottom: 40px;
+			// margin-bottom: 40px; 
 			margin-left: auto;
 			margin-right: auto;
 


### PR DESCRIPTION
The styling of this grid is a little unorganized; while not overtly noticeable it does effect user experience in an understated way. The icons were centered for small mq views but left aligned for others. I thought it looked cleaner to center everything in the grid items uniformly for each media queries.

It also bothered me that the first item had only a title and no text. I made my suggested change, I feel like this helps with both visual and content uniformity.

I looked at this page from responsive and mobile views, I believe this is the only place the grid is used, but should you choose to accept this PR, please check further to make sure my style changes didn't adversely effect anything else. 